### PR TITLE
Fix: Resolve project discovery issue in launcher

### DIFF
--- a/ui/textual/launcher.py
+++ b/ui/textual/launcher.py
@@ -19,7 +19,10 @@ class ProjectLauncher(App):
     def find_projects(self):
         """Finds projects in the 'projects' directory."""
         projects = []
-        project_dir = "projects"
+        # Construct a path to the 'projects' directory relative to this script's location
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        project_dir = os.path.abspath(os.path.join(script_dir, "..", "..", "projects"))
+
         if not os.path.exists(project_dir):
             return []
         for project_name in os.listdir(project_dir):


### PR DESCRIPTION
The launcher was previously unable to find and display projects because it was using a relative path to the `projects` directory. This approach was unreliable as it depended on the current working directory from which the script was executed.

This commit resolves the issue by modifying `launcher.py` to construct an absolute path to the `projects` directory based on the script's own file location. This ensures that the projects are always found, regardless of where the script is run from, making the launcher more robust and reliable.