### PR TITLE
Fix: Correct SCREENS definition in pointsys_ui.py

### DIFF
--- a/ui/textual/pointsys_ui.py
+++ b/ui/textual/pointsys_ui.py
@@ -84,7 +84,7 @@ class LoginScreen(Screen):
                 else:
                     core.rollback_session(self.parent.files)
                 core.start_session(self.parent.files)
-                self.app.push_screen(AccountScreen())
+                self.app.push_screen("account")
 
             if core.has_crashed(account_name):
                 self.app.push_screen(
@@ -93,7 +93,7 @@ class LoginScreen(Screen):
                 )
             else:
                 core.start_session(self.parent.files)
-                self.app.push_screen(AccountScreen())
+                self.app.push_screen("account")
 
 class AccountScreen(Screen):
     """Screen for managing an account."""
@@ -234,7 +234,7 @@ class PointSysApp(App):
         width: 100%;
     }
     """
-    SCREENS = {"login": LoginScreen(), "account": AccountScreen()}
+    SCREENS = {"login": LoginScreen, "account": AccountScreen}
 
     account_name = None
     files = None


### PR DESCRIPTION
The `SCREENS` dictionary in the `PointSysApp` class was previously populated with instances of screen classes, which caused a `ValueError` upon application startup.

This commit corrects the `SCREENS` dictionary to use the screen classes themselves, as required by the Textual framework. It also updates the `push_screen` calls to use the string identifiers for the screens instead of creating new instances.