### PR TITLE
Fix: Correct point addition in Textual UI

### DIFF
--- a/ui/textual/pointsys_ui.py
+++ b/ui/textual/pointsys_ui.py
@@ -140,7 +140,7 @@ class AccountScreen(Screen):
                 with Vertical(classes="action-group"):
                     yield Static("[bold]Add Points[/bold]")
                     yield Input(placeholder="Reason (e.g., 'Worked out')", id="add_reason")
-                    yield Input(placeholder="Value (e.g., '$10', '30m')", id="add_value")
+                    yield Input(placeholder="Number of points", id="add_value", type="number")
                     yield Button("Add Points", id="add_points_button")
 
                 with Vertical(classes="action-group"):
@@ -177,10 +177,20 @@ class AccountScreen(Screen):
         if event.button.id == "add_points_button":
             reason = self.query_one("#add_reason").value
             value_str = self.query_one("#add_value").value
-            points, error = core.parse_value_string(value_str)
-            if error:
-                self.set_status(f"Error: {error}", "error")
+
+            if not reason:
+                self.set_status("Error: Reason cannot be empty.", "error")
                 return
+
+            try:
+                points = int(value_str)
+                if points <= 0:
+                    self.set_status("Error: Please enter a positive number for points.", "error")
+                    return
+            except (ValueError, TypeError):
+                self.set_status("Error: Invalid input. Please enter a whole number for points.", "error")
+                return
+
             core.add_points(self.parent.files, points, reason)
             self.update_points()
             self.update_logs()


### PR DESCRIPTION
The Textual UI for the pointsys project was incorrectly using the reward value conversion logic (`core.parse_value_string`) when adding points. This resulted in incorrect point calculations (e.g., entering "10" was treated as 10 minutes and converted to 100 points).

This commit corrects the behavior by:
- Modifying the `on_button_pressed` handler in `AccountScreen` to parse the input value as a direct integer.
- Adding validation to ensure the input is a positive whole number.
- Updating the placeholder text of the input field to "Number of points" to guide the user correctly.
- Setting the input field's type to "number" to improve the user experience.

The core logic remains untouched as the issue was isolated to the UI layer's handling of user input.